### PR TITLE
Fix trivia scoring flow and leaderboard endpoints

### DIFF
--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -3,7 +3,6 @@
 
 const fs = require('fs');
 const path = require('path');
-const Score = require('./score'); // NOT './score.model' or any other variation
 const Sequelize = require('sequelize');
 const process = require('process');
 const dbConfig = require('../config/db.config.js'); // Import your config file

--- a/backend/models/score.model.js
+++ b/backend/models/score.model.js
@@ -1,49 +1,51 @@
-// backend/models/score.js
-const { DataTypes } = require('sequelize');
-const sequelize = require('../config/database');
-const User = require('./user');
-// const Question = require('./question'); // Not directly needed for overall score
+// backend/models/score.model.js
 
-const Score = sequelize.define('scores', {
-    id: {
-        type: DataTypes.INTEGER,
+module.exports = (sequelize, Sequelize) => {
+  const Score = sequelize.define(
+    'scores',
+    {
+      id: {
+        type: Sequelize.INTEGER,
         autoIncrement: true,
-        primaryKey: true
-    },
-    userId: {
-        type: DataTypes.INTEGER,
+        primaryKey: true,
+      },
+      userId: {
+        type: Sequelize.INTEGER,
         allowNull: false,
         references: {
-            model: User, // 'users' is the table name
-            key: 'id'
-        }
+          model: 'users',
+          key: 'id',
+        },
+        field: 'userId',
+      },
+      score: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+      },
+      totalQuestions: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        defaultValue: 0,
+        field: 'totalQuestions',
+      },
+      percentage: {
+        type: Sequelize.DECIMAL(5, 2),
+        allowNull: false,
+        defaultValue: 0,
+      },
     },
-    score: {
-        type: DataTypes.INTEGER,
-        allowNull: false
-    },
-    // REMOVE these fields if this table is for OVERALL game scores
-    // questionId: {
-    //     type: DataTypes.INTEGER,
-    //     allowNull: false,
-    //     references: {
-    //         model: Question, // 'questions' is the table name
-    //         key: 'id'
-    //     }
-    // },
-    // isCorrect: {
-    //     type: DataTypes.BOOLEAN,
-    //     allowNull: false
-    // }
-}, {
-    timestamps: true
-});
+    {
+      tableName: 'scores',
+      timestamps: true,
+    }
+  );
 
-Score.belongsTo(User, { foreignKey: 'userId' });
-User.hasMany(Score, { foreignKey: 'userId' });
+  Score.associate = (models) => {
+    Score.belongsTo(models.users, {
+      foreignKey: 'userId',
+      as: 'user',
+    });
+  };
 
-// REMOVE these associations if questionId is removed
-// Score.belongsTo(Question, { foreignKey: 'questionId' });
-// Question.hasMany(Score, { foreignKey: 'questionId' });
-
-module.exports = Score;
+  return Score;
+};

--- a/backend/routes/score.routes.js
+++ b/backend/routes/score.routes.js
@@ -1,53 +1,13 @@
-// backend/routes/scores.js
-const express = require('express');
-const router = express.Router();
-const { Score, User } = require('../models'); // Assuming models are exported from an index.js in models
-// or const Score = require('../models/score'); const User = require('../models/user');
+// backend/routes/score.routes.js
+const controller = require('../controllers/score.controller');
+const { authJwt } = require('../middleware');
 
-// POST a new score
-router.post('/', async (req, res) => {
-    try {
-        const { username, score } = req.body;
+module.exports = function registerScoreRoutes(app) {
+  const router = require('express').Router();
 
-        if (!username || score === undefined) {
-            return res.status(400).json({ message: "Username and score are required." });
-        }
+  router.post('/', [authJwt.verifyToken], controller.submitScore);
+  router.get('/my-history', [authJwt.verifyToken], controller.getUserScoreHistory);
+  router.get('/cultivated', controller.getCultivated);
 
-        // Find the user by username to get their ID
-        const user = await User.findOne({ where: { username: username } });
-        if (!user) {
-            return res.status(404).json({ message: "User not found." });
-        }
-
-        // Create the score entry with userId
-        const newScore = await Score.create({
-            userId: user.id,
-            score: parseInt(score, 10) // Ensure score is an integer
-        });
-        res.status(201).json(newScore);
-    } catch (error) {
-        console.error("Error creating score:", error);
-        // Provide more specific error message from Sequelize if available
-        const errorMessage = error.errors ? error.errors.map(e => e.message).join(', ') : error.message;
-        res.status(500).json({ message: "Failed to submit score/stats.", error: errorMessage });
-    }
-});
-
-// GET all scores (example, you might want to join with User to get username)
-router.get('/', async (req, res) => {
-    try {
-        const scores = await Score.findAll({
-            include: [{
-                model: User,
-                attributes: ['username'] // Only include username from User model
-            }],
-            order: [['score', 'DESC']] // Order by score descending
-        });
-        res.json(scores);
-    } catch (error) {
-        console.error("Error fetching scores:", error);
-        res.status(500).json({ message: "Failed to fetch scores.", error: error.message });
-    }
-});
-
-module.exports = router;
+  app.use('/api/scores', router);
+};

--- a/frontend/src/components/Layout/Header.js
+++ b/frontend/src/components/Layout/Header.js
@@ -14,7 +14,6 @@ import {
     IdentificationIcon,
     CogIcon,
     BookOpenIcon,
-    ArrowPathIcon // Keep loading icon if used elsewhere (like dropdown)
 } from '@heroicons/react/24/outline';
 
 function Header() {
@@ -24,7 +23,6 @@ function Header() {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   // Keep state for potential use in dropdown or other features
   const [showCultivatedLink, setShowCultivatedLink] = useState(false);
-  const [isLoadingSummary, setIsLoadingSummary] = useState(false); // Keep for dropdown
 
   const isAdminOrMod = currentUser?.roles?.includes('ROLE_ADMIN') || currentUser?.roles?.includes('ROLE_MODERATOR');
 
@@ -46,7 +44,6 @@ function Header() {
     }
 
     const fetchSummaryForHeader = async () => {
-        setIsLoadingSummary(true); // Still set loading for potential dropdown use
         try {
           const response = await apiService.get('/stats/summary');
           // Still set the state based on mastery for potential dropdown use
@@ -54,8 +51,6 @@ function Header() {
         } catch (error) {
           console.error(">>> Header: Error fetching summary for card link:", error);
           setShowCultivatedLink(false);
-        } finally {
-          setIsLoadingSummary(false); // Clear loading state
         }
     };
     fetchSummaryForHeader();

--- a/frontend/src/components/TriviaGame.js
+++ b/frontend/src/components/TriviaGame.js
@@ -1,324 +1,364 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import apiService from '../services/api';
 import Spinner from './Spinner';
 import { useAuth } from '../contexts/AuthContext';
 
-function TriviaGame() {
-  console.log(">>> TriviaGame component function executing (mounting/re-rendering)");
+const GAME_STATES = {
+  LOADING: 'loading',
+  READY: 'ready',
+  EMPTY: 'empty',
+  ERROR: 'error',
+  FINISHED: 'finished',
+};
 
-  const [questions, setQuestions] = useState([]);
-  const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
-  const [score, setScore] = useState(0);
-  const [selectedAnswer, setSelectedAnswer] = useState(null);
-  const [isAnswered, setIsAnswered] = useState(false);
-  const [isLoading, setIsLoading] = useState(true); // Start loading
-  const [error, setError] = useState(null);
-  const [showExplanation, setShowExplanation] = useState(false);
-  const [isSubmittingScore, setIsSubmittingScore] = useState(false);
-  const [scoreSubmitError, setScoreSubmitError] = useState(null);
-  const sessionResults = useRef([]);
+const createSubmissionState = () => ({ isSubmitting: false, error: null, success: false });
+
+const normaliseAnswer = (value) => (typeof value === 'string' ? value.trim() : value);
+
+function TriviaGame() {
   const { currentUser } = useAuth();
 
-  // Function to submit score
-  const submitScoreAndStats = useCallback(async (finalScore, totalQuestions, results) => {
-    console.log(">>> submitScore called. currentUser:", currentUser);
-    if (!currentUser || !currentUser.accessToken) { console.log(">>> Skipping score submission."); setScoreSubmitError("Log in to save scores."); return; }
-    if (totalQuestions <= 0 || !Array.isArray(results) || results.length !== totalQuestions) { console.warn(">>> Invalid data for score submission"); setScoreSubmitError("Internal error."); return; }
-    setIsSubmittingScore(true); setScoreSubmitError(null);
-    
-    const payload = {
-      score: finalScore,
-      totalQuestions: totalQuestions,
-      results: results, // Add the results array to the payload
-      // quizId: "someQuizId", // Optional: if you have a quiz ID for the session
-      // categoryId: "someCategoryId", // Optional: if the session belongs to a specific category
-    };
-    console.log(`>>> Attempting POST /api/scores:`, payload);
-    try {
-      const response = await apiService.post('/scores', payload);
-      console.log(">>> Score submitted successfully:", response.data);
-      // Set success state or clear error after successful submission
-      setScoreSubmitError(null); // Clear any previous errors
-    } catch (err) {
-      console.error(">>> Error submitting score:", err.response?.data || err.message || err);
-      const submitError = err.response?.data?.message || err.message || "Failed.";
-      setScoreSubmitError(submitError);
-    } finally {
-      setIsSubmittingScore(false);
-    }
-  }, [currentUser]);
+  const [gameState, setGameState] = useState(GAME_STATES.LOADING);
+  const [questions, setQuestions] = useState([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [score, setScore] = useState(0);
+  const [selectedAnswer, setSelectedAnswer] = useState(null);
+  const [showExplanation, setShowExplanation] = useState(false);
+  const [fetchError, setFetchError] = useState(null);
+  const [submissionState, setSubmissionState] = useState(() => createSubmissionState());
 
-  // Function to fetch questions
-  const fetchQuestions = useCallback(async () => {
-    console.log(">>> fetchQuestions CALLED.");
-    // Reset state for a new game
-    setQuestions([]); setCurrentQuestionIndex(0); setScore(0); setSelectedAnswer(null); setIsAnswered(false); setShowExplanation(false); setIsLoading(true); setError(null); setScoreSubmitError(null); sessionResults.current = [];
+  const resultsRef = useRef([]);
+
+  const totalQuestions = questions.length;
+  const currentQuestion = useMemo(() => questions[currentIndex] ?? null, [questions, currentIndex]);
+  const hasAnswered = selectedAnswer !== null;
+
+  const resetGameState = useCallback(() => {
+    setQuestions([]);
+    setCurrentIndex(0);
+    setScore(0);
+    setSelectedAnswer(null);
+    setShowExplanation(false);
+    setFetchError(null);
+    setSubmissionState(createSubmissionState());
+    resultsRef.current = [];
+  }, []);
+
+  const loadQuestions = useCallback(async () => {
+    resetGameState();
+    setGameState(GAME_STATES.LOADING);
+
     try {
-      console.log(">>> Attempting API call to /trivia/questions");
       const response = await apiService.get('/trivia/questions');
+      const fetchedQuestions = Array.isArray(response.data?.data) ? response.data.data : [];
 
-      // Expecting response.data to have a 'data' property which is the array
-      const fetchedData = response.data?.data || [];
-      console.log(">>> API Response Data:", fetchedData);
-
-      if (Array.isArray(fetchedData) && fetchedData.length > 0) {
-          // *** VERIFICATION STEP: Check if the expected 'correct_answer' key exists ***
-          const firstQuestionHasAnswer = fetchedData[0] && typeof fetchedData[0].correct_answer !== 'undefined';
-          if (!firstQuestionHasAnswer) {
-              console.warn(`>>> WARNING: First question fetched does not seem to have the expected answer property ('correct_answer'). Check API response structure and backend controller!`);
-          }
-          // Shuffle the fetched questions randomly
-          const shuffled = [...fetchedData].sort(() => Math.random() - 0.5);
-          setQuestions(shuffled);
-          console.log(">>> Questions state SET with:", shuffled);
-      } else {
-          setQuestions([]);
-          console.log(">>> Questions state remains empty or fetchedData is not an array.");
-          // Set an error if the data format was unexpected but the request succeeded
-          if (!Array.isArray(fetchedData) && response.status === 200) {
-              setError("Invalid data format received from server.");
-          } else if (fetchedData.length === 0 && response.status === 200) {
-              // Handle the specific message from the backend for no more questions
-              setError(response.data?.message || "No trivia questions available.");
-          }
-      }
-    } catch (err) {
-        console.error(">>> Error fetching questions:", err);
-        setError(err.response?.data?.message || err.message || 'Failed to fetch questions.');
-        setQuestions([]); // Ensure questions are empty on error
-    } finally {
-        setIsLoading(false);
-        console.log(">>> fetchQuestions FINALLY block, isLoading: false");
-    }
-  }, []); // No dependencies needed here as it resets everything
-
-  // Effect to fetch questions on mount
-  useEffect(() => {
-    console.log(">>> useEffect RUNNING.");
-    fetchQuestions();
-  }, [fetchQuestions]); // Depend on fetchQuestions
-
-  // Event Handlers
-  const handleAnswerSelect = (option) => {
-    console.log(">>> handleAnswerSelect called with option:", option);
-    if (isAnswered) { console.log(">>> Already answered."); return; }
-
-    // Ensure questions array and index are valid
-    if (!questions || questions.length === 0 || currentQuestionIndex >= questions.length) {
-        console.error(`>>> handleAnswerSelect: ERROR - Invalid questions state or index ${currentQuestionIndex}.`);
+      if (fetchedQuestions.length === 0) {
+        setFetchError(response.data?.message || 'No trivia questions available.');
+        setGameState(GAME_STATES.EMPTY);
         return;
+      }
+
+      const sanitisedQuestions = fetchedQuestions.map((question) => ({
+        id: question.id,
+        question: question.question,
+        options: Array.isArray(question.options) ? question.options : [],
+        correctAnswer: question.correct_answer,
+        explanation: question.explanation,
+        category: question.category,
+        subCategory: question.sub_category,
+      }));
+
+      setQuestions(sanitisedQuestions);
+      setGameState(GAME_STATES.READY);
+    } catch (error) {
+      setFetchError(error.response?.data?.message || error.message || 'Failed to fetch questions.');
+      setGameState(GAME_STATES.ERROR);
     }
-    const currentQuestion = questions[currentQuestionIndex];
-    if (!currentQuestion) { console.error(`>>> handleAnswerSelect: ERROR - Could not find question at index ${currentQuestionIndex} in state!`); return; }
+  }, [resetGameState]);
 
-    // *** USE 'correct_answer' KEY ***
-    const correctAnswer = currentQuestion.correct_answer;
+  useEffect(() => {
+    loadQuestions();
+  }, [loadQuestions]);
 
-    console.log(">>> handleAnswerSelect: Current Question Data derived from state:", currentQuestion);
-    console.log(`>>> Comparing Selected: "${option}" (Type: ${typeof option})`);
-    // Check if correctAnswer is undefined and log a warning if so
-    if (typeof correctAnswer === 'undefined') {
-        console.warn(`>>> WARNING: Correct answer is undefined for question ID ${currentQuestion.id}. Check the 'correct_answer' property in the API response.`);
+  const handleAnswerSelect = useCallback(
+    (option) => {
+      if (!currentQuestion || hasAnswered) {
+        return;
+      }
+
+      const isCorrect = normaliseAnswer(option) === normaliseAnswer(currentQuestion.correctAnswer);
+
+      setSelectedAnswer(option);
+      setShowExplanation(true);
+      if (isCorrect) {
+        setScore((previous) => previous + 1);
+      }
+
+      const questionId = Number(currentQuestion.id);
+      if (Number.isInteger(questionId)) {
+        resultsRef.current.push({ questionId, isCorrect });
+      } else {
+        console.warn('Question missing numeric identifier. Skipping result submission for this question.', currentQuestion);
+      }
+    },
+    [currentQuestion, hasAnswered]
+  );
+
+  const finaliseGame = useCallback(() => {
+    setSelectedAnswer(null);
+    setShowExplanation(false);
+    setGameState(GAME_STATES.FINISHED);
+
+    const sanitizedResults = resultsRef.current
+      .map((result) => ({
+        questionId: Number(result.questionId),
+        isCorrect: Boolean(result.isCorrect),
+      }))
+      .filter((result) => Number.isInteger(result.questionId));
+
+    resultsRef.current = sanitizedResults;
+
+    const computedScore = sanitizedResults.filter((result) => result.isCorrect).length;
+    setScore(computedScore);
+
+    if (sanitizedResults.length !== totalQuestions) {
+      setSubmissionState({
+        isSubmitting: false,
+        error: 'Unable to save score because some questions were missing identifiers.',
+        success: false,
+      });
+      return;
     }
-    console.log(`>>> With Correct Answer from State: "${correctAnswer}" (Type: ${typeof correctAnswer})`);
 
-    // Trimmed comparison (good practice, handles potential whitespace issues)
-    // Ensure both values are strings before trimming
-    const selectedTrimmed = typeof option === 'string' ? option.trim() : option;
-    const correctTrimmed = typeof correctAnswer === 'string' ? correctAnswer.trim() : correctAnswer;
+    if (!currentUser?.accessToken) {
+      return;
+    }
 
-    const isCorrectTrimmed = selectedTrimmed === correctTrimmed;
-    console.log(`>>> Comparison Result (Trimmed):`, isCorrectTrimmed);
+    setSubmissionState({ isSubmitting: true, error: null, success: false });
 
-    setSelectedAnswer(option);
-    setIsAnswered(true);
-    setShowExplanation(true); // Show explanation immediately
+    (async () => {
+      try {
+        await apiService.post('/scores', {
+          score: computedScore,
+          totalQuestions: sanitizedResults.length,
+          results: sanitizedResults,
+        });
+        setSubmissionState({ isSubmitting: false, error: null, success: true });
+      } catch (error) {
+        setSubmissionState({
+          isSubmitting: false,
+          error: error.response?.data?.message || error.message || 'Failed to save score.',
+          success: false,
+        });
+      }
+    })();
+  }, [currentUser, totalQuestions]);
 
-    if (isCorrectTrimmed) {
-        console.log(">>> Incrementing score!");
-        setScore(prev => prev + 1);
+  const handleNextQuestion = useCallback(() => {
+    if (!hasAnswered) {
+      return;
+    }
+
+    const nextIndex = currentIndex + 1;
+    if (nextIndex < totalQuestions) {
+      setCurrentIndex(nextIndex);
+      setSelectedAnswer(null);
+      setShowExplanation(false);
     } else {
-        console.log(">>> Answer incorrect.");
+      finaliseGame();
     }
+  }, [currentIndex, finaliseGame, hasAnswered, totalQuestions]);
 
-    // Ensure currentQuestion.id exists before pushing result
-    sessionResults.current.push({ questionId: currentQuestion.id || `index_${currentQuestionIndex}`, isCorrect: isCorrectTrimmed });
-    console.log(">>> Recorded result:", sessionResults.current[sessionResults.current.length - 1]);
-  };
+  const handleRestart = useCallback(() => {
+    loadQuestions();
+  }, [loadQuestions]);
 
-  const handleNextQuestion = () => {
-    const nextIndex = currentQuestionIndex + 1;
-    setSelectedAnswer(null); setIsAnswered(false); setShowExplanation(false);
-    if (nextIndex < questions.length) {
-        console.log(">>> handleNextQuestion: Moving to next:", nextIndex);
-        setCurrentQuestionIndex(nextIndex);
-    } else {
-        console.log(`>>> handleNextQuestion: Game finished! Score: ${score}/${questions.length}`);
-        // Only submit if there were questions
-        if (questions.length > 0) {
-            submitScoreAndStats(score, questions.length, sessionResults.current);
-        }
-        setCurrentQuestionIndex(questions.length); // Go to game over state
-    }
-  };
-
-   const handleRestartGame = () => {
-       console.log("Restarting game...");
-       fetchQuestions(); // Refetch questions to restart
-   };
-
-  // --- Render Logic ---
-  console.log(">>> Rendering State:", { isLoading, error, questionsLength: questions.length, currentQuestionIndex, isGameOver: currentQuestionIndex >= questions.length });
-
-  if (isLoading) { console.log(">>> Rendering: Spinner"); return <Spinner />; }
-
-  // Display error message if fetching failed or no questions were returned with a message
-  if (error && questions.length === 0) {
-      console.log(">>> Rendering: Error / No Questions Message");
-      return (
-          <div className="text-center p-4 bg-yellow-100 dark:bg-yellow-900 border border-yellow-300 dark:border-yellow-700 text-yellow-800 dark:text-yellow-200 rounded-md shadow max-w-xl mx-auto">
-              <p className="font-semibold">Notice:</p>
-              <p>{error}</p>
-              <button onClick={handleRestartGame} className="mt-4 bg-blue-500 hover:bg-blue-600 text-white font-medium py-1 px-4 rounded transition duration-200">
-                  Try Again
-              </button>
-          </div>
-      );
+  if (gameState === GAME_STATES.LOADING) {
+    return <Spinner />;
   }
 
-  // Handle case where fetching finished successfully but resulted in zero questions (e.g., user answered all)
-  // This check is slightly redundant if the error state above catches the backend message, but provides a fallback.
-  if (!isLoading && !error && questions.length === 0) {
-      console.log(">>> Rendering: No Questions Available (Fallback)");
-      return (
-          <div className="text-center p-5">
-              <p className="text-gray-500 dark:text-gray-400">No trivia questions available at the moment, or you've answered them all!</p>
-              <button onClick={handleRestartGame} className="mt-4 bg-blue-500 hover:bg-blue-600 text-white font-medium py-1 px-4 rounded transition duration-200">
-                  Start New Game
-              </button>
-          </div>
-      );
+  if (gameState === GAME_STATES.ERROR || gameState === GAME_STATES.EMPTY) {
+    return (
+      <div className="text-center p-4 bg-yellow-100 dark:bg-yellow-900 border border-yellow-300 dark:border-yellow-700 text-yellow-800 dark:text-yellow-200 rounded-md shadow max-w-xl mx-auto">
+        <p className="font-semibold mb-2">{gameState === GAME_STATES.ERROR ? 'Something went wrong' : 'Notice'}</p>
+        <p className="mb-4">{fetchError}</p>
+        <button
+          type="button"
+          onClick={handleRestart}
+          className="mt-2 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded transition duration-200"
+        >
+          Try Again
+        </button>
+      </div>
+    );
   }
 
-   const isGameOver = currentQuestionIndex >= questions.length;
+  if (gameState === GAME_STATES.FINISHED) {
+    const percentage = totalQuestions > 0 ? Math.round((score / totalQuestions) * 100) : 0;
+    let message = 'Good effort!';
+    if (percentage >= 80) {
+      message = 'Excellent knowledge!';
+    } else if (percentage >= 60) {
+      message = 'Well done!';
+    }
 
-   // Render Game Over Screen
-   if (isGameOver) {
-       console.log(">>> Rendering: Game Over");
-       const totalQuestions = questions.length; // Use stored length
-       const percentage = totalQuestions > 0 ? Math.round((score / totalQuestions) * 100) : 0;
-       let message = "Good effort!"; if (percentage >= 80) message = "Excellent knowledge!"; else if (percentage >= 60) message = "Well done!";
+    return (
+      <div className="text-center p-6 bg-white dark:bg-gray-800 rounded-lg shadow-lg max-w-xl mx-auto border border-gray-200 dark:border-gray-700">
+        <h2 className="text-3xl font-bold mb-4 text-green-700 dark:text-green-400">Trivia Complete!</h2>
+        <p className="text-xl mb-2 dark:text-gray-200">Your final score:</p>
+        <p className="text-4xl font-bold mb-4 dark:text-gray-100">
+          {score}
+          {' '}/
+          {totalQuestions}
+        </p>
+        <p className="text-2xl font-semibold mb-6 text-indigo-600 dark:text-indigo-400">({percentage}%)</p>
+        <p className="text-lg mb-6 italic dark:text-gray-300">{message}</p>
 
-       return (
-        <div className="text-center p-6 bg-white dark:bg-gray-800 rounded-lg shadow-lg max-w-xl mx-auto border border-gray-200 dark:border-gray-700">
-            <h2 className="text-3xl font-bold mb-4 text-green-700 dark:text-green-400">Trivia Complete!</h2>
-            <p className="text-xl mb-2 dark:text-gray-200">Your final score:</p>
-            <p className="text-4xl font-bold mb-4 dark:text-gray-100">{score} / {totalQuestions}</p>
-            <p className="text-2xl font-semibold mb-6 text-indigo-600 dark:text-indigo-400">({percentage}%)</p>
-            <p className="text-lg mb-6 italic dark:text-gray-300">{message}</p>
-            {/* Score Submission Status */}
-            {currentUser && (
-                 <div className="text-sm my-4 flex items-center justify-center min-h-[20px]">
-                    {isSubmittingScore ? (
-                        <><Spinner size="sm" /> <span className="ml-2 text-gray-500 dark:text-gray-400">Submitting score...</span></>
-                    ) : scoreSubmitError ? (
-                        <span className="text-red-500 dark:text-red-400">Could not save score: {scoreSubmitError}</span>
-                    ) : (
-                         // Show success only if submission was attempted and succeeded
-                         !isSubmittingScore && scoreSubmitError === null && sessionResults.current.length > 0 && <span className="text-green-600 dark:text-green-400">Score submitted!</span>
-                    )}
-                </div>
+        {currentUser ? (
+          <div className="text-sm my-4 flex items-center justify-center min-h-[20px]">
+            {submissionState.isSubmitting && (
+              <>
+                <Spinner size="sm" />
+                <span className="ml-2 text-gray-500 dark:text-gray-400">Submitting score...</span>
+              </>
             )}
-            {!currentUser && ( <p className="text-sm text-gray-500 dark:text-gray-400 my-4">Log in or register to save your score!</p> )}
-            <button onClick={handleRestartGame} className="bg-blue-500 hover:bg-blue-600 text-white font-semibold py-3 px-8 rounded-lg transition duration-200 text-lg mt-4">Play Again?</button>
-        </div>
-       );
-   }
+            {!submissionState.isSubmitting && submissionState.error && (
+              <span className="text-red-500 dark:text-red-400">Could not save score: {submissionState.error}</span>
+            )}
+            {!submissionState.isSubmitting && !submissionState.error && submissionState.success && (
+              <span className="text-green-600 dark:text-green-400">Score submitted!</span>
+            )}
+          </div>
+        ) : (
+          <p className="text-sm text-gray-500 dark:text-gray-400 my-4">Log in or register to save your score!</p>
+        )}
 
-  // Get current question object - ensure it exists before proceeding
-  const currentQuestion = questions[currentQuestionIndex];
-  if (!currentQuestion) {
-      console.error(`>>> Rendering: ERROR - currentQuestion is null/undefined at index ${currentQuestionIndex}. This shouldn't happen if loading/error states are correct.`);
-      // Render a fallback or spinner
-      return <Spinner />; // Or handle more gracefully, maybe show an error message
+        <button
+          type="button"
+          onClick={handleRestart}
+          className="bg-blue-500 hover:bg-blue-600 text-white font-semibold py-3 px-8 rounded-lg transition duration-200 text-lg mt-4"
+        >
+          Play Again?
+        </button>
+      </div>
+    );
   }
 
-  // *** USE 'correct_answer' KEY ***
-  const correctAnswer = currentQuestion.correct_answer;
-  const correctTrimmedAnswer = typeof correctAnswer === 'string' ? correctAnswer.trim() : correctAnswer;
+  if (!currentQuestion) {
+    return <Spinner />;
+  }
 
-  // Render Active Question UI
-  console.log(">>> Rendering: Active Question UI (ID:", currentQuestion.id, ")");
+  const correctAnswer = normaliseAnswer(currentQuestion.correctAnswer);
+  const selectedAnswerNormalised = normaliseAnswer(selectedAnswer);
+
   return (
     <div className="p-4 md:p-6 bg-white dark:bg-gray-800 rounded-lg shadow-lg max-w-2xl mx-auto font-inter border border-gray-200 dark:border-gray-700 w-full">
-      {/* Header Section */}
       <div className="mb-6 pb-4 border-b border-gray-200 dark:border-gray-700 flex flex-wrap justify-between items-center gap-2">
         <div className="order-1 text-xs font-medium text-indigo-700 dark:text-indigo-300">
-            <span className="bg-indigo-100 dark:bg-indigo-900 px-2 py-0.5 rounded-full mr-1">{currentQuestion?.category || 'General'}</span>
-            {/* Optional: Display sub_category if it exists */}
-            {currentQuestion?.sub_category && (<span className="bg-gray-100 dark:bg-gray-600 px-2 py-0.5 rounded-full">{currentQuestion.sub_category}</span>)}
+          <span className="bg-indigo-100 dark:bg-indigo-900 px-2 py-0.5 rounded-full mr-1">{currentQuestion.category || 'General'}</span>
+          {currentQuestion.subCategory && (
+            <span className="bg-gray-100 dark:bg-gray-600 px-2 py-0.5 rounded-full">{currentQuestion.subCategory}</span>
+          )}
         </div>
-        <span className="text-lg font-bold text-gray-700 dark:text-gray-300 order-3 sm:order-2 w-full sm:w-auto text-center sm:text-left"> Question {currentQuestionIndex + 1} / {questions.length} </span>
-        <span className="text-lg font-bold text-green-600 dark:text-green-400 order-2 sm:order-3"> Score: {score} </span>
+        <span className="text-lg font-bold text-gray-700 dark:text-gray-300 order-3 sm:order-2 w-full sm:w-auto text-center sm:text-left">
+          Question
+          {' '}
+          {currentIndex + 1}
+          {' '}/
+          {totalQuestions}
+        </span>
+        <span className="text-lg font-bold text-green-600 dark:text-green-400 order-2 sm:order-3">Score: {score}</span>
       </div>
-      {/* Question */}
-      <h2 className="text-xl md:text-2xl font-semibold text-gray-800 dark:text-gray-100 mb-6 whitespace-pre-line"> {currentQuestion?.question || 'Loading question...'} </h2>
-      {/* Options */}
+
+      <h2 className="text-xl md:text-2xl font-semibold text-gray-800 dark:text-gray-100 mb-6 whitespace-pre-line">
+        {currentQuestion.question}
+      </h2>
+
       <div className="space-y-3 mb-6">
-        {Array.isArray(currentQuestion?.options) ? (
-          currentQuestion.options.map((option, index) => {
-            let buttonClass = "w-full text-left p-3 border rounded-lg transition duration-150 ease-in-out text-gray-700 dark:text-gray-200 ";
-            if (isAnswered) {
-              buttonClass += 'cursor-not-allowed ';
-              // Use trimmed comparison for styling
-              const optionTrimmed = typeof option === 'string' ? option.trim() : option;
-              const selectedTrimmed = typeof selectedAnswer === 'string' ? selectedAnswer.trim() : selectedAnswer;
+        {currentQuestion.options.map((option, index) => {
+          const optionNormalised = normaliseAnswer(option);
+          let buttonClass = 'w-full text-left p-3 border rounded-lg transition duration-150 ease-in-out text-gray-700 dark:text-gray-200 ';
 
-              // *** USE 'correct_answer' KEY (via correctTrimmedAnswer) ***
-              const isCorrectOption = optionTrimmed === correctTrimmedAnswer;
-              const isSelectedOption = optionTrimmed === selectedTrimmed;
+          if (hasAnswered) {
+            buttonClass += 'cursor-not-allowed ';
 
-              if (isCorrectOption) {
-                  buttonClass += "bg-green-100 dark:bg-green-900 border-green-400 dark:border-green-600 text-green-800 dark:text-green-100 font-semibold ring-2 ring-green-300";
-              } else if (isSelectedOption) {
-                  buttonClass += "bg-red-100 dark:bg-red-900 border-red-400 dark:border-red-600 text-red-800 dark:text-red-100"; // Incorrect selection
-              } else {
-                  buttonClass += "bg-gray-100 dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-500 dark:text-gray-400 opacity-70"; // Other incorrect options
-              }
+            const isCorrectOption = optionNormalised === correctAnswer;
+            const isSelectedOption = optionNormalised === selectedAnswerNormalised;
+
+            if (isCorrectOption) {
+              buttonClass += 'bg-green-100 dark:bg-green-900 border-green-400 dark:border-green-600 text-green-800 dark:text-green-100 font-semibold ring-2 ring-green-300 ';
+            } else if (isSelectedOption) {
+              buttonClass += 'bg-red-100 dark:bg-red-900 border-red-400 dark:border-red-600 text-red-800 dark:text-red-100 ';
             } else {
-                buttonClass += "border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-indigo-500";
+              buttonClass += 'bg-gray-100 dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-500 dark:text-gray-400 opacity-70 ';
             }
-            // Ensure key is unique and stable
-            const key = `${currentQuestion.id || `q${currentQuestionIndex}`}-option-${index}`;
-            return ( <button key={key} onClick={() => handleAnswerSelect(option)} disabled={isAnswered} className={buttonClass} aria-pressed={selectedAnswer === option}> {option} </button> );
-          })
-        ) : ( <p className="text-red-500 dark:text-red-400">Error: Options missing or invalid for this question.</p> )}
+          } else {
+            buttonClass += 'border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-indigo-500 ';
+          }
+
+          const key = `${currentQuestion.id}-option-${index}`;
+
+          return (
+            <button
+              key={key}
+              type="button"
+              onClick={() => handleAnswerSelect(option)}
+              disabled={hasAnswered}
+              className={buttonClass}
+              aria-pressed={optionNormalised === selectedAnswerNormalised}
+            >
+              {option}
+            </button>
+          );
+        })}
       </div>
-      {/* Explanation */}
-      {isAnswered && showExplanation && (
-        // *** USE 'correct_answer' KEY (via correctTrimmedAnswer) ***
-        <div className={`p-4 rounded-lg mb-6 text-sm ${ (typeof selectedAnswer === 'string' ? selectedAnswer.trim() : selectedAnswer) === correctTrimmedAnswer ? 'bg-green-50 dark:bg-green-900 border border-green-200 dark:border-green-700' : 'bg-red-50 dark:bg-red-900 border border-red-200 dark:border-red-700' }`}>
-          <h3 className="font-bold text-lg mb-2 dark:text-gray-100">{ (typeof selectedAnswer === 'string' ? selectedAnswer.trim() : selectedAnswer) === correctTrimmedAnswer ? 'Correct!' : 'Incorrect' }</h3>
-          {/* Display correct answer if incorrect */}
-          { (typeof selectedAnswer === 'string' ? selectedAnswer.trim() : selectedAnswer) !== correctTrimmedAnswer && (
-            // *** USE 'correct_answer' KEY (via correctAnswer) ***
-            <p className="text-gray-700 dark:text-gray-300 mb-2">Correct Answer: <span className="font-semibold">{correctAnswer ?? 'Not available'}</span></p> // Handle case where correct answer might still be missing
+
+      {hasAnswered && showExplanation && (
+        <div
+          className={`p-4 rounded-lg mb-6 text-sm ${selectedAnswerNormalised === correctAnswer ? 'bg-green-50 dark:bg-green-900 border border-green-200 dark:border-green-700' : 'bg-red-50 dark:bg-red-900 border border-red-200 dark:border-red-700'}`}
+        >
+          <h3 className="font-bold text-lg mb-2 dark:text-gray-100">
+            {selectedAnswerNormalised === correctAnswer ? 'Correct!' : 'Incorrect'}
+          </h3>
+          {selectedAnswerNormalised !== correctAnswer && (
+            <p className="text-gray-700 dark:text-gray-300 mb-2">
+              Correct Answer:
+              {' '}
+              <span className="font-semibold">{currentQuestion.correctAnswer ?? 'Not available'}</span>
+            </p>
           )}
-          {/* Display explanation if available */}
-          {currentQuestion?.explanation && (
-              <p className="text-gray-700 dark:text-gray-300">{currentQuestion.explanation}</p>
+          {currentQuestion.explanation && (
+            <p className="text-gray-700 dark:text-gray-300">{currentQuestion.explanation}</p>
           )}
-          {/* Fallback if explanation is missing */}
-          {!currentQuestion?.explanation && (typeof selectedAnswer === 'string' ? selectedAnswer.trim() : selectedAnswer) !== correctTrimmedAnswer && (
-              <p className="text-gray-700 dark:text-gray-300 italic">No explanation provided for this question.</p>
+          {!currentQuestion.explanation && selectedAnswerNormalised !== correctAnswer && (
+            <p className="text-gray-700 dark:text-gray-300 italic">No explanation provided for this question.</p>
           )}
         </div>
       )}
-      {/* Next Button */}
-      {isAnswered && ( <div className="text-center mt-6"> <button onClick={handleNextQuestion} className="bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-8 rounded-lg transition duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"> {currentQuestionIndex < questions.length - 1 ? 'Next Question' : 'Finish Trivia'} </button> </div> )}
-      {/* Restart Button */}
-      <div className="text-center mt-4 pt-4 border-t border-gray-100 dark:border-gray-700"> <button onClick={handleRestartGame} className="text-sm text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 underline"> Restart Game </button> </div>
+
+      {hasAnswered && (
+        <div className="text-center mt-6">
+          <button
+            type="button"
+            onClick={handleNextQuestion}
+            className="bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-8 rounded-lg transition duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+          >
+            {currentIndex < totalQuestions - 1 ? 'Next Question' : 'Finish Trivia'}
+          </button>
+        </div>
+      )}
+
+      <div className="text-center mt-4 pt-4 border-t border-gray-100 dark:border-gray-700">
+        <button
+          type="button"
+          onClick={handleRestart}
+          className="text-sm text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 underline"
+        >
+          Restart Game
+        </button>
+      </div>
     </div>
   );
 }
+
 export default TriviaGame;

--- a/frontend/src/pages/ResourceGuidePage.js
+++ b/frontend/src/pages/ResourceGuidePage.js
@@ -6,7 +6,6 @@ import {
     Box,
     List,
     ListItem,
-    ListItemText,
     Paper,
     Link as MuiLink,
     InputAdornment
@@ -806,7 +805,6 @@ function ResourceGuidePage() {
                                 underline="hover" // Consistent underline behavior
                                 className="!text-sm !text-gray-700 dark:!text-gray-300 hover:!text-blue-600 dark:hover:!text-blue-400 w-full block px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700" // Added padding/hover styles
                             >
-                                {/* Removed ListItemText for simpler structure, Link text is sufficient */}
                                 {item.title}
                             </MuiLink>
                         </ListItem>


### PR DESCRIPTION
## Summary
- rebuild the score model and REST routes so score submissions and cultivated leaderboard use the same API surface
- harden score submission handling by validating payloads, recomputing totals, and exposing mastery results with the correct associations
- refactor the trivia game client to manage loading/error/game-over states cleanly, submit results to the API, and tidy up unused imports flagged by lint

## Testing
- CI=true npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e597c6bf488332b196ae5644c09708